### PR TITLE
Bugfix: Fix verification data section not showing in Presentation.

### DIFF
--- a/common-feature/src/main/java/eu/europa/ec/commonfeature/model/DocumentTypeUi.kt
+++ b/common-feature/src/main/java/eu/europa/ec/commonfeature/model/DocumentTypeUi.kt
@@ -20,7 +20,6 @@ import eu.europa.ec.commonfeature.ui.document_details.model.DocumentDetailsUi
 import eu.europa.ec.corelogic.model.DocumentIdentifier
 import eu.europa.ec.corelogic.model.isSupported
 import eu.europa.ec.corelogic.model.toDocumentIdentifier
-import eu.europa.ec.eudi.iso18013.transfer.response.RequestedDocument
 import eu.europa.ec.eudi.wallet.document.Document
 import eu.europa.ec.eudi.wallet.document.DocumentId
 import eu.europa.ec.resourceslogic.R
@@ -57,14 +56,6 @@ fun Document.toUiName(resourceProvider: ResourceProvider): String {
     val docIdentifier = this.toDocumentIdentifier()
     return docIdentifier.toUiName(
         fallbackDocName = this.name,
-        resourceProvider = resourceProvider
-    )
-}
-
-fun RequestedDocument.toUiName(resourceProvider: ResourceProvider): String {
-    val docIdentifier = this.toDocumentIdentifier()
-    return docIdentifier.toUiName(
-        fallbackDocName = this.documentId,
         resourceProvider = resourceProvider
     )
 }

--- a/common-feature/src/main/java/eu/europa/ec/commonfeature/ui/request/transformer/RequestTransformer.kt
+++ b/common-feature/src/main/java/eu/europa/ec/commonfeature/ui/request/transformer/RequestTransformer.kt
@@ -107,18 +107,18 @@ object RequestTransformer {
                 }
 
                 if (
-                    getMandatoryFields(documentIdentifier = requestDocument.toDocumentIdentifier())
+                    getMandatoryFields(documentIdentifier = storageDocument.toDocumentIdentifier())
                         .contains(docItem.elementIdentifier)
                 ) {
                     required.add(
                         docItem.toRequestDocumentItemUi(
                             uID = produceDocUID(
-                                docItem.elementIdentifier,
-                                requestDocument.documentId,
-                                storageDocument.docType
+                                elementIdentifier = docItem.elementIdentifier,
+                                documentId = storageDocument.id,
+                                docType = storageDocument.docType
                             ),
                             docPayload = DocumentItemDomainPayload(
-                                docId = requestDocument.documentId,
+                                docId = storageDocument.id,
                                 docType = storageDocument.docType,
                                 namespace = docItem.namespace,
                                 elementIdentifier = docItem.elementIdentifier,
@@ -132,9 +132,9 @@ object RequestTransformer {
                     )
                 } else {
                     val uID = produceDocUID(
-                        docItem.elementIdentifier,
-                        requestDocument.documentId,
-                        storageDocument.docType
+                        elementIdentifier = docItem.elementIdentifier,
+                        documentId = storageDocument.id,
+                        docType = storageDocument.docType
                     )
 
                     items += RequestDataUi.Space()
@@ -143,7 +143,7 @@ object RequestTransformer {
                             requestDocumentItemUi = docItem.toRequestDocumentItemUi(
                                 uID = uID,
                                 docPayload = DocumentItemDomainPayload(
-                                    docId = requestDocument.documentId,
+                                    docId = storageDocument.id,
                                     docType = storageDocument.docType,
                                     namespace = docItem.namespace,
                                     elementIdentifier = docItem.elementIdentifier,

--- a/core-logic/src/main/java/eu/europa/ec/corelogic/model/DocumentIdentifier.kt
+++ b/core-logic/src/main/java/eu/europa/ec/corelogic/model/DocumentIdentifier.kt
@@ -16,7 +16,6 @@
 
 package eu.europa.ec.corelogic.model
 
-import eu.europa.ec.eudi.iso18013.transfer.response.RequestedDocument
 import eu.europa.ec.eudi.wallet.document.Document
 import eu.europa.ec.eudi.wallet.document.IssuedDocument
 import eu.europa.ec.eudi.wallet.document.format.MsoMdocFormat
@@ -94,13 +93,6 @@ fun DocType.toDocumentIdentifier(): DocumentIdentifier = when (this) {
 fun Document.toDocumentIdentifier(): DocumentIdentifier {
     val nameSpace = (this as? IssuedDocument)?.nameSpaces?.keys?.firstOrNull().orEmpty()
     val docType = (this.format as? MsoMdocFormat)?.docType.orEmpty()
-
-    return createDocumentIdentifier(nameSpace, docType)
-}
-
-fun RequestedDocument.toDocumentIdentifier(): DocumentIdentifier {
-    val nameSpace = this.requestedItems.keys.firstOrNull()?.namespace.orEmpty()
-    val docType = ""
 
     return createDocumentIdentifier(nameSpace, docType)
 }


### PR DESCRIPTION
# Description of changes
- `requestDocument.toDocumentIdentifier()` is no longer valid since `RequestedDocument` has no docType (as it used to) and can no longer produce a valid `DocumentIdentifier`. So instead, use the document from storage for that, as it holds such information and is equivalent.
- Update produceDocUID function to accept named parameters for clarity.
- Remove obsolete RequestedDocument extension functions in DocumentTypeUi and DocumentIdentifier.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test suite run successfully
- [ ] Added Tests ()

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have checked that my views are *accessible*
- [x] I have checked that my strings are *localized* where applicable