### PR TITLE
Add ability to generate a graph of gradle project dependencies.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,5 +31,6 @@ plugins {
     alias(libs.plugins.baselineprofile) apply false
     alias(libs.plugins.compose.compiler) apply false
     alias(libs.plugins.androidx.room) apply false
+    alias(libs.plugins.dependencyGraph)
 }
 true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,6 +29,7 @@ androidxBiometric = "1.2.0-alpha05"
 androidxAppAuth = "1.0.0"
 coil = "3.3.0"
 constraintlayoutVersion = "1.1.1"
+dependencyGraphPlugin = "0.4"
 gmsPlugin = "4.4.4"
 junit4 = "4.13.2"
 kotlin = "2.2.21"
@@ -173,6 +174,7 @@ androidx-room-gradlePlugin = { group = "androidx.room", name = "room-gradle-plug
 android-application = { id = "com.android.application", version.ref = "androidGradlePlugin" }
 android-library = { id = "com.android.library", version.ref = "androidGradlePlugin" }
 android-test = { id = "com.android.test", version.ref = "androidGradlePlugin" }
+dependencyGraph = { id = "com.gitlab.stfs.gradle.dependency-graph-plugin", version.ref = "dependencyGraphPlugin"}
 gms = { id = "com.google.gms.google-services", version.ref = "gmsPlugin" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }


### PR DESCRIPTION
To generate:

```
./gradlew dependencyGraph
```

Results will be in:

 - `build/reports/dependencyGraph/dependencyGraph.dot`
 - `build/reports/dependencyGraph/dependencyGraph.png`

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Generated dependency graph, see below for output.

# Checklist:

- [x] I have performed a self-review of my own code

<img width="1986" height="692" alt="dependencyGraph" src="https://github.com/user-attachments/assets/a493631c-70d6-4266-bd93-40c830afb86b" />