### PR TITLE
refactor: decouple navigation and deep link logic into specialized helper files

### DIFF
--- a/core-logic/src/main/java/eu/europa/ec/corelogic/worker/ReIssuanceWorkManager.kt
+++ b/core-logic/src/main/java/eu/europa/ec/corelogic/worker/ReIssuanceWorkManager.kt
@@ -25,6 +25,7 @@ import eu.europa.ec.corelogic.controller.IssueDocumentsPartialState
 import eu.europa.ec.corelogic.controller.WalletCoreDocumentsController
 import eu.europa.ec.corelogic.util.CoreActions
 import eu.europa.ec.corelogic.util.CoreActions.RE_ISSUANCE_IDS_DETAILS_EXTRA
+import eu.europa.ec.eudi.wallet.document.CreateDocumentSettings.CredentialPolicy
 import eu.europa.ec.storagelogic.dao.FailedReIssuedDocumentDao
 import eu.europa.ec.storagelogic.model.FailedReIssuedDocument
 import kotlinx.coroutines.flow.first
@@ -63,13 +64,15 @@ class ReIssuanceWorkManager(
 
                     val belowMinCount =
                         credential.credentialsCount() <= config.minNumberOfCredentials
+                    val hasOneTimeUsePolicy =
+                        credential.credentialPolicy == CredentialPolicy.OneTimeUse
 
                     val expiresWithinThreshold =
                         credential.getValidUntil()
                             .map { validUntil -> validUntil.isBefore(expirationLimit) }
                             .getOrDefault(false)
 
-                    belowMinCount || expiresWithinThreshold
+                    (belowMinCount && hasOneTimeUsePolicy) || expiresWithinThreshold
                 }
                 .forEach { document ->
 

--- a/core-logic/src/main/java/eu/europa/ec/corelogic/worker/ReIssuanceWorkManager.kt
+++ b/core-logic/src/main/java/eu/europa/ec/corelogic/worker/ReIssuanceWorkManager.kt
@@ -64,15 +64,16 @@ class ReIssuanceWorkManager(
 
                     val belowMinCount =
                         credential.credentialsCount() <= config.minNumberOfCredentials
-                    val hasOneTimeUsePolicy =
-                        credential.credentialPolicy == CredentialPolicy.OneTimeUse
+
+                    val hasRotationUsePolicy =
+                        credential.credentialPolicy == CredentialPolicy.RotateUse
 
                     val expiresWithinThreshold =
                         credential.getValidUntil()
                             .map { validUntil -> validUntil.isBefore(expirationLimit) }
                             .getOrDefault(false)
 
-                    (belowMinCount && hasOneTimeUsePolicy) || expiresWithinThreshold
+                    (belowMinCount && hasRotationUsePolicy) || expiresWithinThreshold
                 }
                 .forEach { document ->
 

--- a/ui-logic/src/main/java/eu/europa/ec/uilogic/navigation/helper/DeepLinkAction.kt
+++ b/ui-logic/src/main/java/eu/europa/ec/uilogic/navigation/helper/DeepLinkAction.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2025 European Commission
+ *
+ * Licensed under the EUPL, Version 1.2 or - as soon they will be approved by the European
+ * Commission - subsequent versions of the EUPL (the "Licence"); You may not use this work
+ * except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the Licence for the specific language
+ * governing permissions and limitations under the Licence.
+ */
+
+package eu.europa.ec.uilogic.navigation.helper
+
+import android.net.Uri
+import eu.europa.ec.uilogic.BuildConfig
+
+data class DeepLinkAction(
+    val link: Uri,
+    val type: DeepLinkType
+)
+
+enum class DeepLinkType(
+    val schemas: List<String>,
+    val host: String? = null
+) {
+    OPENID4VP(
+        schemas = listOf(
+            BuildConfig.OPENID4VP_SCHEME,
+            BuildConfig.EUDI_OPENID4VP_SCHEME,
+            BuildConfig.MDOC_OPENID4VP_SCHEME,
+            BuildConfig.HAIP_OPENID4VP_SCHEME
+        )
+    ),
+    CREDENTIAL_OFFER(
+        schemas = listOf(
+            BuildConfig.CREDENTIAL_OFFER_SCHEME,
+            BuildConfig.CREDENTIAL_OFFER_HAIP_SCHEME
+        )
+    ),
+    ISSUANCE(
+        schemas = listOf(BuildConfig.ISSUE_AUTHORIZATION_SCHEME),
+        host = BuildConfig.ISSUE_AUTHORIZATION_HOST
+    ),
+    EXTERNAL(
+        emptyList()
+    ),
+    DYNAMIC_PRESENTATION(
+        emptyList()
+    ),
+    RQES(
+        schemas = listOf(BuildConfig.RQES_SCHEME),
+        host = BuildConfig.RQES_HOST
+    ),
+    RQES_DOC_RETRIEVAL(
+        schemas = listOf(BuildConfig.RQES_DOC_RETRIEVAL_SCHEME)
+    );
+
+    companion object {
+        fun parse(scheme: String, host: String? = null): DeepLinkType = when {
+
+            OPENID4VP.schemas.contains(scheme) -> {
+                OPENID4VP
+            }
+
+            CREDENTIAL_OFFER.schemas.contains(scheme) -> {
+                CREDENTIAL_OFFER
+            }
+
+            ISSUANCE.schemas.contains(scheme) && host == ISSUANCE.host -> {
+                ISSUANCE
+            }
+
+            RQES.schemas.contains(scheme) && host == RQES.host -> {
+                RQES
+            }
+
+            RQES_DOC_RETRIEVAL.schemas.contains(scheme) -> {
+                RQES_DOC_RETRIEVAL
+            }
+
+            else -> EXTERNAL
+        }
+    }
+}

--- a/ui-logic/src/main/java/eu/europa/ec/uilogic/navigation/helper/DeepLinkHelper.kt
+++ b/ui-logic/src/main/java/eu/europa/ec/uilogic/navigation/helper/DeepLinkHelper.kt
@@ -20,82 +20,30 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
-import android.os.Parcelable
 import androidx.core.os.bundleOf
 import androidx.navigation.NavController
-import eu.europa.ec.businesslogic.extension.toUri
 import eu.europa.ec.businesslogic.util.safeLet
 import eu.europa.ec.corelogic.util.CoreActions
 import eu.europa.ec.eudi.rqesui.infrastructure.EudiRQESUi
 import eu.europa.ec.eudi.rqesui.infrastructure.RemoteUri
-import eu.europa.ec.uilogic.BuildConfig
-import eu.europa.ec.uilogic.container.EudiComponentActivity
-import eu.europa.ec.uilogic.extension.navigateWithIntentAction
 import eu.europa.ec.uilogic.extension.openUrl
 import eu.europa.ec.uilogic.navigation.IssuanceScreens
 import eu.europa.ec.uilogic.navigation.PresentationScreens
 import eu.europa.ec.uilogic.navigation.Screen
-import kotlinx.parcelize.Parcelize
-
-fun <T> generateComposableArguments(arguments: Map<String, T>): String {
-    if (arguments.isEmpty()) return ""
-    return StringBuilder().apply {
-        append("?")
-        arguments.onEachIndexed { index, entry ->
-            if (index > 0) {
-                append("&")
-            }
-            append("${entry.key}=${entry.value}")
-        }
-    }.toString()
-}
-
-fun generateComposableDeepLinkUri(screen: Screen, arguments: String): Uri =
-    generateComposableDeepLinkUri(screen.screenName, arguments)
-
-fun generateComposableDeepLinkUri(screen: String, arguments: String): Uri =
-    "${BuildConfig.DEEPLINK}/${screen}$arguments".toUri()
-
-fun generateComposableNavigationLink(screen: Screen, arguments: String): String =
-    generateComposableNavigationLink(screen.screenName, arguments)
-
-fun generateComposableNavigationLink(screen: String, arguments: String): String =
-    "${screen}$arguments"
-
-fun generateNewTaskDeepLink(
-    context: Context,
-    screen: Screen,
-    arguments: String = "",
-    flags: Int = 0
-): Intent =
-    generateNewTaskDeepLink(context, screen.screenName, arguments, flags)
-
-fun generateNewTaskDeepLink(
-    context: Context,
-    screen: String,
-    arguments: String = "",
-    flags: Int = 0
-): Intent =
-    Intent(
-        Intent.ACTION_VIEW,
-        generateComposableDeepLinkUri(screen, arguments),
-        context,
-        EudiComponentActivity::class.java
-    ).apply {
-        addFlags(flags)
-    }
 
 fun hasDeepLink(deepLinkUri: Uri?): DeepLinkAction? {
     return safeLet(
         deepLinkUri,
         deepLinkUri?.scheme
     ) { uri, scheme ->
-        DeepLinkAction(link = uri, type = DeepLinkType.parse(scheme, uri.host))
+        DeepLinkAction(
+            link = uri,
+            type = DeepLinkType.parse(
+                scheme = scheme,
+                host = uri.host
+            )
+        )
     }
-}
-
-fun hasIntentAction(intent: Intent?): IntentAction? {
-    return intent?.toIntentAction()
 }
 
 fun handleDeepLinkAction(
@@ -104,37 +52,12 @@ fun handleDeepLinkAction(
     arguments: String? = null
 ) {
     hasDeepLink(uri)?.let { action ->
-        handleDeepLinkAction(navController, action, arguments)
-    }
-}
-
-fun handleIntentAction(
-    navController: NavController,
-    action: IntentAction,
-    arguments: String? = null
-) {
-    val screen: Screen
-
-    when (action.type) {
-        IntentType.DC_API -> {
-            screen = PresentationScreens.PresentationRequest
-        }
-    }
-
-    val navigationLink = arguments?.let {
-        generateComposableNavigationLink(
-            screen = screen,
+        handleDeepLinkAction(
+            navController = navController,
+            action = action,
             arguments = arguments
         )
-    } ?: screen.screenRoute
-
-    navController.navigateWithIntentAction(
-        route = navigationLink,
-        intentAction = action,
-        builder = {
-            popUpTo(screen.screenRoute) { inclusive = true }
-        }
-    )
+    }
 }
 
 fun handleDeepLinkAction(
@@ -142,22 +65,20 @@ fun handleDeepLinkAction(
     action: DeepLinkAction,
     arguments: String? = null
 ) {
-    val screen: Screen
-
-    when (action.type) {
+    val screen: Screen = when (action.type) {
         DeepLinkType.OPENID4VP -> {
-            screen = PresentationScreens.PresentationRequest
+            PresentationScreens.PresentationRequest
         }
 
         DeepLinkType.CREDENTIAL_OFFER -> {
-            screen = IssuanceScreens.DocumentOffer
+            IssuanceScreens.DocumentOffer
         }
 
         DeepLinkType.ISSUANCE -> {
             notify(
-                navController.context,
-                CoreActions.VCI_RESUME_ACTION,
-                bundleOf(Pair("uri", action.link.toString()))
+                context = navController.context,
+                action = CoreActions.VCI_RESUME_ACTION,
+                bundle = bundleOf(Pair("uri", action.link.toString()))
             )
             return
         }
@@ -169,18 +90,18 @@ fun handleDeepLinkAction(
 
         DeepLinkType.DYNAMIC_PRESENTATION -> {
             notify(
-                navController.context,
-                CoreActions.VCI_DYNAMIC_PRESENTATION,
-                bundleOf(Pair("uri", action.link.toString()))
+                context = navController.context,
+                action = CoreActions.VCI_DYNAMIC_PRESENTATION,
+                bundle = bundleOf(Pair("uri", action.link.toString()))
             )
             return
         }
 
         DeepLinkType.RQES -> {
-            action.link.getQueryParameter("code")?.let {
+            action.link.getQueryParameter("code")?.let { authorizationCode ->
                 EudiRQESUi.resume(
                     context = navController.context,
-                    authorizationCode = it
+                    authorizationCode = authorizationCode
                 )
             }
             return
@@ -203,104 +124,20 @@ fun handleDeepLinkAction(
     } ?: screen.screenRoute
 
     navController.navigate(navigationLink) {
-        popUpTo(screen.screenRoute) { inclusive = true }
-    }
-}
-
-const val INTENT_ACTION_KEY = "intent_action"
-
-@Parcelize
-data class IntentAction(
-    val intent: Intent,
-    val type: IntentType
-) : Parcelable
-
-enum class IntentType(val associatedActions: List<String>) {
-    DC_API(
-        associatedActions = listOf(
-            "androidx.identitycredentials.action.get_credentials",
-            "androidx.credentials.registry.provider.action.get_credential"
-        )
-    ),
-}
-
-data class DeepLinkAction(val link: Uri, val type: DeepLinkType)
-enum class DeepLinkType(val schemas: List<String>, val host: String? = null) {
-
-    OPENID4VP(
-        schemas = listOf(
-            BuildConfig.OPENID4VP_SCHEME,
-            BuildConfig.EUDI_OPENID4VP_SCHEME,
-            BuildConfig.MDOC_OPENID4VP_SCHEME,
-            BuildConfig.HAIP_OPENID4VP_SCHEME
-        )
-    ),
-    CREDENTIAL_OFFER(
-        schemas = listOf(
-            BuildConfig.CREDENTIAL_OFFER_SCHEME,
-            BuildConfig.CREDENTIAL_OFFER_HAIP_SCHEME
-        )
-    ),
-    ISSUANCE(
-        schemas = listOf(BuildConfig.ISSUE_AUTHORIZATION_SCHEME),
-        host = BuildConfig.ISSUE_AUTHORIZATION_HOST
-    ),
-    EXTERNAL(
-        emptyList()
-    ),
-    DYNAMIC_PRESENTATION(
-        emptyList()
-    ),
-    RQES(
-        schemas = listOf(BuildConfig.RQES_SCHEME),
-        host = BuildConfig.RQES_HOST
-    ),
-    RQES_DOC_RETRIEVAL(
-        schemas = listOf(BuildConfig.RQES_DOC_RETRIEVAL_SCHEME)
-    );
-
-    companion object {
-        fun parse(scheme: String, host: String? = null): DeepLinkType = when {
-
-            OPENID4VP.schemas.contains(scheme) -> {
-                OPENID4VP
-            }
-
-            CREDENTIAL_OFFER.schemas.contains(scheme) -> {
-                CREDENTIAL_OFFER
-            }
-
-            ISSUANCE.schemas.contains(scheme) && host == ISSUANCE.host -> {
-                ISSUANCE
-            }
-
-            RQES.schemas.contains(scheme) && host == RQES.host -> {
-                RQES
-            }
-
-            RQES_DOC_RETRIEVAL.schemas.contains(scheme) -> {
-                RQES_DOC_RETRIEVAL
-            }
-
-            else -> EXTERNAL
+        popUpTo(screen.screenRoute) {
+            inclusive = true
         }
     }
 }
 
-private fun notify(context: Context, action: String, bundle: Bundle? = null) {
+private fun notify(
+    context: Context,
+    action: String,
+    bundle: Bundle? = null
+) {
     Intent().also { intent ->
         intent.action = action
         bundle?.let { intent.putExtras(it) }
         context.sendBroadcast(intent)
     }
-}
-
-private fun Intent.toIntentAction(): IntentAction? {
-    return IntentType
-        .entries
-        .firstOrNull {
-            it.associatedActions.contains(this.action?.lowercase())
-        }?.let { matchedType ->
-            IntentAction(intent = this, type = matchedType)
-        }
 }

--- a/ui-logic/src/main/java/eu/europa/ec/uilogic/navigation/helper/IntentAction.kt
+++ b/ui-logic/src/main/java/eu/europa/ec/uilogic/navigation/helper/IntentAction.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2025 European Commission
+ *
+ * Licensed under the EUPL, Version 1.2 or - as soon they will be approved by the European
+ * Commission - subsequent versions of the EUPL (the "Licence"); You may not use this work
+ * except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the Licence for the specific language
+ * governing permissions and limitations under the Licence.
+ */
+
+package eu.europa.ec.uilogic.navigation.helper
+
+import android.content.Intent
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+const val INTENT_ACTION_KEY = "intent_action"
+
+@Parcelize
+data class IntentAction(
+    val intent: Intent,
+    val type: IntentType
+) : Parcelable
+
+enum class IntentType(val associatedActions: List<String>) {
+    DC_API(
+        associatedActions = listOf(
+            "androidx.identitycredentials.action.get_credentials",
+            "androidx.credentials.registry.provider.action.get_credential"
+        )
+    ),
+}
+

--- a/ui-logic/src/main/java/eu/europa/ec/uilogic/navigation/helper/IntentActionHelper.kt
+++ b/ui-logic/src/main/java/eu/europa/ec/uilogic/navigation/helper/IntentActionHelper.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2025 European Commission
+ *
+ * Licensed under the EUPL, Version 1.2 or - as soon they will be approved by the European
+ * Commission - subsequent versions of the EUPL (the "Licence"); You may not use this work
+ * except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the Licence for the specific language
+ * governing permissions and limitations under the Licence.
+ */
+
+package eu.europa.ec.uilogic.navigation.helper
+
+import android.content.Intent
+import androidx.navigation.NavController
+import eu.europa.ec.uilogic.extension.navigateWithIntentAction
+import eu.europa.ec.uilogic.navigation.PresentationScreens
+import eu.europa.ec.uilogic.navigation.Screen
+
+fun hasIntentAction(intent: Intent?): IntentAction? {
+    return intent?.toIntentAction()
+}
+
+fun handleIntentAction(
+    navController: NavController,
+    action: IntentAction,
+    arguments: String? = null
+) {
+    val screen: Screen = when (action.type) {
+        IntentType.DC_API -> PresentationScreens.PresentationRequest
+    }
+
+    val navigationLink = arguments?.let {
+        generateComposableNavigationLink(
+            screen = screen,
+            arguments = arguments
+        )
+    } ?: screen.screenRoute
+
+    navController.navigateWithIntentAction(
+        route = navigationLink,
+        intentAction = action,
+        builder = {
+            popUpTo(screen.screenRoute) {
+                inclusive = true
+            }
+        }
+    )
+}
+
+private fun Intent.toIntentAction(): IntentAction? {
+    return IntentType
+        .entries
+        .firstOrNull {
+            it.associatedActions.contains(this.action?.lowercase())
+        }?.let { matchedType ->
+            IntentAction(intent = this, type = matchedType)
+        }
+}

--- a/ui-logic/src/main/java/eu/europa/ec/uilogic/navigation/helper/NavigationRouteHelper.kt
+++ b/ui-logic/src/main/java/eu/europa/ec/uilogic/navigation/helper/NavigationRouteHelper.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2025 European Commission
+ *
+ * Licensed under the EUPL, Version 1.2 or - as soon they will be approved by the European
+ * Commission - subsequent versions of the EUPL (the "Licence"); You may not use this work
+ * except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the Licence for the specific language
+ * governing permissions and limitations under the Licence.
+ */
+
+package eu.europa.ec.uilogic.navigation.helper
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import eu.europa.ec.businesslogic.extension.toUri
+import eu.europa.ec.uilogic.BuildConfig
+import eu.europa.ec.uilogic.container.EudiComponentActivity
+import eu.europa.ec.uilogic.navigation.Screen
+
+fun <T> generateComposableArguments(arguments: Map<String, T>): String {
+    if (arguments.isEmpty()) return ""
+    return StringBuilder().apply {
+        append("?")
+        arguments.onEachIndexed { index, entry ->
+            if (index > 0) {
+                append("&")
+            }
+            append("${entry.key}=${entry.value}")
+        }
+    }.toString()
+}
+
+fun generateComposableDeepLinkUri(screen: Screen, arguments: String): Uri =
+    generateComposableDeepLinkUri(screen.screenName, arguments)
+
+fun generateComposableDeepLinkUri(screen: String, arguments: String): Uri =
+    "${BuildConfig.DEEPLINK}/${screen}$arguments".toUri()
+
+fun generateComposableNavigationLink(screen: Screen, arguments: String): String =
+    generateComposableNavigationLink(screen.screenName, arguments)
+
+fun generateComposableNavigationLink(screen: String, arguments: String): String =
+    "${screen}$arguments"
+
+fun generateNewTaskDeepLink(
+    context: Context,
+    screen: Screen,
+    arguments: String = "",
+    flags: Int = 0
+): Intent =
+    generateNewTaskDeepLink(context, screen.screenName, arguments, flags)
+
+fun generateNewTaskDeepLink(
+    context: Context,
+    screen: String,
+    arguments: String = "",
+    flags: Int = 0
+): Intent =
+    Intent(
+        Intent.ACTION_VIEW,
+        generateComposableDeepLinkUri(screen, arguments),
+        context,
+        EudiComponentActivity::class.java
+    ).apply {
+        addFlags(flags)
+    }


### PR DESCRIPTION
This commit refactors the navigation logic within the `ui-logic` module by extracting specialized functionality from `DeepLinkHelper.kt` into separate files. This improves maintainability and follows the single responsibility principle.

Key changes:
- **`NavigationRouteHelper.kt`**: Created to house generic composable argument generation, deep link URI creation, and navigation link/intent generation logic.
- **`IntentAction.kt` & `IntentActionHelper.kt`**: Extracted `IntentAction` data structures and handling logic, specifically for managing `DC_API` (Digital Credential API) actions.
- **`DeepLinkAction.kt`**: Extracted `DeepLinkAction` and `DeepLinkType` definitions, including the parsing logic for various OpenID4VP, Credential Offer, and RQES schemes.
- **`DeepLinkHelper.kt`**: Refactored to focus exclusively on routing deep link actions to the appropriate application screens or broadcasting system intents.
- **Code Cleanup**: Applied consistent formatting and named arguments across the modified navigation helpers.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other fix (maintenance or house-keeping)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test suite run successfully
- [ ] Added Tests ()

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have checked that my views are *accessible*
- [x] I have checked that my strings are *localized* where applicable