### PR TITLE
fix: Improve OpenId4VciManager lookup in WalletCoreDocumentsController

### DIFF
--- a/core-logic/src/main/java/eu/europa/ec/corelogic/controller/WalletCoreDocumentsController.kt
+++ b/core-logic/src/main/java/eu/europa/ec/corelogic/controller/WalletCoreDocumentsController.kt
@@ -415,7 +415,7 @@ class WalletCoreDocumentsControllerImpl(
         val manager: OpenId4VciManager? =
             openId4VciManagers.entries.find { (vciConfig, _) ->
                 vciConfig.config.issuerUrl == issuerId
-            }?.value
+            }?.value ?: openId4VciManagers.values.firstOrNull()
         require(manager != null) { documentErrorMessage }
 
         manager.reissueDocument(


### PR DESCRIPTION
This commit updates the `reissueDocument` logic to provide a fallback when a manager for a specific `issuerId` is not found. If the initial lookup by URL fails, the controller now defaults to the first available `OpenId4VciManager` instead of immediately failing.

Key changes:
- Modified the `manager` resolution in `WalletCoreDocumentsController.reissueDocument` to use `firstOrNull()` as a fallback after searching by `issuerId`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test suite run successfully
- [ ] Added Tests ()

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have checked that my views are *accessible*
- [x] I have checked that my strings are *localized* where applicable